### PR TITLE
Plugin structure + Generate credentials endpoint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve('@backstage/cli/config/eslint.backend')],
+};

--- a/README.md
+++ b/README.md
@@ -1,3 +1,59 @@
-# sentry-backend
+# aws-backend
 
-Simple plugin forwarding requests to [Sentry](https://sentry.io) API.
+Backend plugin that generates temporary credentials in order to perform requests to aws services from backstage's frontend
+
+## Usage
+
+This is how you set api keys when using aws sdk:
+
+```js
+async function generateCredentials(backendUrl: string) {
+  const resp = await (await fetch(`${backendUrl}/aws/credentials`)).json();
+  return new AWS.Credentials({
+    accessKeyId: resp.AccessKeyId,
+    secretAccessKey: resp.SecretAccessKey,
+    sessionToken: resp.SessionToken,
+  });
+}
+AWS.config.credentials = await generateCredentials(backendUrl);
+```
+
+## Starting the Auth Backend
+
+Please create an IAM user (with api keys capabilities) with permissions as little as possible to perform actions from backstage (e.g. only operation lambda:GetFunction with specified resource list)
+
+then, please set environment variables with api keys from previously create IAM user.
+
+Then run plugin as standalone:
+
+```bash
+export AWS_ACCESS_KEY_ID=x
+export AWS_ACCESS_KEY_SECRET=x
+yarn start
+```
+
+or add it to backstage:
+
+```js
+// packages/backend/src/plugins/aws.ts
+
+import { createRouter } from '@roadiehq/backstage-plugin-aws-auth';
+import type { PluginEnvironment } from '../types';
+
+export default async function createPlugin({ logger }: PluginEnvironment) {
+  return await createRouter(logger);
+}
+```
+
+```js
+// packages/backend/src/index.ts
+
+import aws from './plugins/aws';
+...
+const awsEnv = useHotMemoize(module, () => createEnv('aws'));
+...
+const service = createServiceBuilder(module)
+    .loadConfig(configReader
+    .addRouter('/aws', await aws(awsEnv))
+    ....
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@roadiehq/backstage-plugin-aws-auth",
+  "version": "0.1.1",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "scripts": {
+    "start": "backstage-cli backend:dev",
+    "build": "backstage-cli backend:build",
+    "lint": "backstage-cli lint",
+    "test": "backstage-cli test",
+    "prepack": "backstage-cli prepack",
+    "postpack": "backstage-cli postpack",
+    "clean": "backstage-cli clean"
+  },
+  "dependencies": {
+    "@backstage/backend-common": "^0.1.1-alpha.23",
+    "@types/express": "^4.17.6",
+    "aws-sdk": "^2.734.0",
+    "compression": "^1.7.4",
+    "cors": "^2.8.5",
+    "express": "^4.17.1",
+    "express-promise-router": "^3.0.3",
+    "fs-extra": "^9.0.0",
+    "helmet": "^4.0.0",
+    "morgan": "^1.10.0",
+    "winston": "^3.2.1",
+    "yn": "^4.0.0"
+  },
+  "devDependencies": {
+    "@backstage/cli": "^0.1.1-alpha.23",
+    "jest-fetch-mock": "^3.0.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './service/router';

--- a/src/service/aws-api.ts
+++ b/src/service/aws-api.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import express from 'express';
+import { Logger } from 'winston';
+import AWS from 'aws-sdk';
+
+export type LambdaData = {
+  region: string;
+  functionName: string;
+  codeSize: number;
+  description: string;
+  lastModifiedDate: string;
+  runtime: string;
+  memory: number;
+};
+
+async function generateTemporaryCredentials(
+  AWS_ACCESS_KEY_ID: string,
+  AWS_ACCESS_KEY_SECRET: string,
+) {
+  AWS.config.credentials = new AWS.Credentials({
+    accessKeyId: AWS_ACCESS_KEY_ID,
+    secretAccessKey: AWS_ACCESS_KEY_SECRET,
+  });
+
+  const creds = await new AWS.STS()
+    .getSessionToken({
+      DurationSeconds: 900,
+    })
+    .promise();
+  return creds;
+}
+
+export function getAwsApiGenerateTempCredentialsForwarder(
+  AWS_ACCESS_KEY_ID: string,
+  AWS_ACCESS_KEY_SECRET: string,
+  logger: Logger,
+) {
+  return async function forwardRequest(
+    _: express.Request,
+    response: express.Response,
+  ) {
+    try {
+      const credentials = await generateTemporaryCredentials(
+        AWS_ACCESS_KEY_ID,
+        AWS_ACCESS_KEY_SECRET,
+      );
+      return response.json(credentials.Credentials);
+    } catch (e) {
+      logger.error(e);
+      return response.status(500).json({ message: e.message });
+    }
+  };
+}

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Logger } from 'winston';
+import Router from 'express-promise-router';
+import express from 'express';
+import { getAwsApiGenerateTempCredentialsForwarder } from './aws-api';
+
+export async function createRouter(logger: Logger): Promise<express.Router> {
+  const router = Router();
+  router.use(express.json());
+
+  const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
+  const AWS_ACCESS_KEY_SECRET = process.env.AWS_ACCESS_KEY_SECRET;
+  if (!AWS_ACCESS_KEY_ID || !AWS_ACCESS_KEY_SECRET) {
+    if (process.env.NODE_ENV !== 'development') {
+      throw new Error(
+        'AWS api tokens must be provided in AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET environment variables to start the API.',
+      );
+    }
+    logger.warn(
+      'Failed to initialize AWS backend, set AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET environment variable to start the API.',
+    );
+  } else {
+    const awsApiGenerateTempCredentialsForwarder = getAwsApiGenerateTempCredentialsForwarder(
+      AWS_ACCESS_KEY_ID,
+      AWS_ACCESS_KEY_SECRET,
+      logger,
+    );
+    router.use('/credentials', awsApiGenerateTempCredentialsForwarder);
+  }
+
+  return router;
+}

--- a/src/service/standaloneApplication.ts
+++ b/src/service/standaloneApplication.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  errorHandler,
+  notFoundHandler,
+  requestLoggingHandler,
+} from '@backstage/backend-common';
+import cors from 'cors';
+import express from 'express';
+import helmet from 'helmet';
+import { Logger } from 'winston';
+import { createRouter } from './router';
+
+export async function createStandaloneApplication(
+  logger: Logger,
+): Promise<express.Application> {
+  const app = express();
+
+  app.use(helmet());
+  app.use(cors());
+  app.use(express.json());
+  app.use(requestLoggingHandler());
+  app.use('/', await createRouter(logger));
+  app.use(notFoundHandler());
+  app.use(errorHandler());
+
+  return app;
+}

--- a/src/service/standaloneServer.ts
+++ b/src/service/standaloneServer.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Server } from 'http';
+import { Logger } from 'winston';
+import { createStandaloneApplication } from './standaloneApplication';
+
+export async function startStandaloneServer(
+  parentLogger: Logger,
+): Promise<Server> {
+  const logger = parentLogger.child({ service: 'scaffolder-backend' });
+  logger.debug('Creating application...');
+
+  const app = await createStandaloneApplication(logger);
+
+  logger.debug('Starting application server...');
+  const PORT = parseInt(process.env.PORT || '5001', 10);
+  return await new Promise((resolve, reject) => {
+    const server = app.listen(PORT, (err?: Error) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      logger.info(`Listening on port ${PORT}`);
+      resolve(server);
+    });
+  });
+}


### PR DESCRIPTION
This backend plugin in some places tries to match the codebase from other backend plugins (e.g. passing env variables from router to endpoints)