### PR TITLE
Try lowercase tag

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
     github.com/project-slug: roadiehq/backstage-plugin-aws-auth
   tags:
     - plugin
-    - OSS
+    - oss
 spec:
   type: library
   owner: group:roadie


### PR DESCRIPTION
I'm currently getting the following error when I try to import the `catalog-info.yaml` into Backstage.

```
InputError: "tags.1" is not valid; expected a string that is sequences of [a-zA-Z0-9] separated by [-], at most 63 characters in total but found "OSS". To learn more about catalog file format, visit: https://github.com/spotify/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md at inputError (/usr/src/app/plugins/catalog-backend/dist/index.cjs.js:728:12) at LocationReaders.handleEntity (/usr/src/app/plugins/catalog-backend/dist/index.cjs.js:898:12) at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

https://github.com/spotify/backstage/issues/3092