### PR TITLE
Feature: Assume Role Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ async function generateCredentials(backendUrl: string) {
 AWS.config.credentials = await generateCredentials(backendUrl);
 ```
 
+### Using an IAM Role for Cross-account
+
+You can specify an AWS IAM Role Arn in the body of the request to facilitate cross-account lookups via the Assume Role methodology. You will need to ensure the IAM credentials made available to Backstage have the `sts:AssumeRole` in its attached IAM policy.
+
+```js
+async function generateCredentials(backendUrl: string) {
+  const reqBody = JSON.stringify({ RoleArn: 'arn:aws:iam::0123456789012:role/Example' });
+  const resp = await (await fetch(`${backendUrl}/aws/credentials`, { body: reqBody })).json();
+  return new AWS.Credentials({
+    accessKeyId: resp.AccessKeyId,
+    secretAccessKey: resp.SecretAccessKey,
+    sessionToken: resp.SessionToken,
+  });
+}
+AWS.config.credentials = await generateCredentials(backendUrl);
+```
+
 ## Starting the Auth Backend
 
 Please create an IAM user (with api keys capabilities) with permissions as little as possible to perform actions from backstage (e.g. only operation lambda:GetFunction with specified resource list)

--- a/src/service/aws-api.test.ts
+++ b/src/service/aws-api.test.ts
@@ -22,9 +22,9 @@ const generateTemporaryCredentials = require('./generateTemporaryCredentials.ts'
 const credentialsStub = 'CREDENTIALS_STUB';
 const keyIdStub = 'TEST_KEY_ID';
 const keySecretStub = 'TEST_KEY_SECRET';
+const roleArnStub = 'arn:aws:iam::123456789012:role/TEST_ROLE';
 
-// eslint-disable-next-line
-var generateTemporaryCredentialsMock = jest.fn((_: string, _2: string) => ({
+const generateTemporaryCredentialsMock = jest.fn((_: string, _2: string, _3: string) => ({
   Credentials: credentialsStub,
 }));
 
@@ -58,7 +58,34 @@ describe('aws-api', () => {
     expect((await response).json).toBeCalledWith(credentialsStub);
     expect(generateTemporaryCredentialsMock).toBeCalledWith(
       keyIdStub,
-      keySecretStub
+      keySecretStub,
+      undefined
+    );
+  });
+
+  it('should respond with auth creds in json with roleArn', async () => {
+    const awsApiGenerateTempCredentialsForwarder = getAwsApiGenerateTempCredentialsForwarder({
+      AWS_ACCESS_KEY_ID: keyIdStub,
+      AWS_ACCESS_KEY_SECRET: keySecretStub,
+      logger: mockLogger
+    });
+
+    const mockResponse = () => {
+      const res = { json: jest.fn };
+      res.json = jest.fn().mockReturnValue(res);
+      return res as any;
+    };
+
+    const response = awsApiGenerateTempCredentialsForwarder(
+      { body: { RoleArn: roleArnStub } } as any,
+      mockResponse()
+    );
+
+    expect((await response).json).toBeCalledWith(credentialsStub);
+    expect(generateTemporaryCredentialsMock).toBeCalledWith(
+      keyIdStub,
+      keySecretStub,
+      roleArnStub
     );
   });
 });

--- a/src/service/aws-api.ts
+++ b/src/service/aws-api.ts
@@ -49,7 +49,6 @@ export function getAwsApiGenerateTempCredentialsForwarder({
       );
       return response.json(credentials.Credentials);
     } catch (e) {
-      console.log(e);
       logger.error(e);
       return response.status(500).json({ message: e.message });
     }

--- a/src/service/aws-api.ts
+++ b/src/service/aws-api.ts
@@ -44,10 +44,12 @@ export function getAwsApiGenerateTempCredentialsForwarder({
     try {
       const credentials = await generateTemporaryCredentials(
         AWS_ACCESS_KEY_ID,
-        AWS_ACCESS_KEY_SECRET
+        AWS_ACCESS_KEY_SECRET,
+        _.body ? _.body.RoleArn : undefined
       );
       return response.json(credentials.Credentials);
     } catch (e) {
+      console.log(e);
       logger.error(e);
       return response.status(500).json({ message: e.message });
     }

--- a/src/service/generateTemporaryCredentials.ts
+++ b/src/service/generateTemporaryCredentials.ts
@@ -2,19 +2,30 @@ import AWS from 'aws-sdk';
 
 export async function generateTemporaryCredentials(
   AWS_ACCESS_KEY_ID?: string,
-  AWS_ACCESS_KEY_SECRET?: string
+  AWS_ACCESS_KEY_SECRET?: string,
+  AWS_ROLE_ARN?: string
 ) {
-  if(AWS_ACCESS_KEY_ID && AWS_ACCESS_KEY_SECRET){
+  const defaultSessionDuration: number = 900;
+  if (AWS_ACCESS_KEY_ID && AWS_ACCESS_KEY_SECRET) {
     AWS.config.credentials = new AWS.Credentials({
       accessKeyId: AWS_ACCESS_KEY_ID,
       secretAccessKey: AWS_ACCESS_KEY_SECRET,
     });
   }
 
-  const creds = await new AWS.STS()
+  if (AWS_ROLE_ARN) {
+    return await new AWS.STS()
+      .assumeRole({
+        RoleArn: AWS_ROLE_ARN,
+        RoleSessionName: 'backstage-plugin-aws-auth',
+        DurationSeconds: defaultSessionDuration,
+      })
+      .promise();
+  }
+
+  return await new AWS.STS()
     .getSessionToken({
-      DurationSeconds: 900,
+      DurationSeconds: defaultSessionDuration,
     })
     .promise();
-  return creds;
 }


### PR DESCRIPTION
Fixes #41 

Looks for a `RoleArn` parameter in the request `body`. If it exists, use the `AssumeRole()` method in the STS SDK, otherwise, simply return a session token for the existing credentials chain.