### PR TITLE
Rename AWS_ACCESS_KEY_SECRET to AWS_SECRET_ACCESS_KEY

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@main
         with:
-          node-version: 12.18.3
+          node-version: 14.17.0
       - run: yarn install
       - run: yarn tsc
       - run: yarn build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roadiehq/backstage-plugin-aws-auth",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/src/service/router.ts
+++ b/src/service/router.ts
@@ -23,10 +23,10 @@ export async function createRouter(logger: Logger): Promise<express.Router> {
   router.use(express.json());
 
   const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID;
-  const AWS_ACCESS_KEY_SECRET = process.env.AWS_ACCESS_KEY_SECRET;
+  const AWS_ACCESS_KEY_SECRET = process.env.AWS_ACCESS_KEY_SECRET || process.env.AWS_SECRET_ACCESS_KEY;
   if (!AWS_ACCESS_KEY_ID || !AWS_ACCESS_KEY_SECRET) {
     logger.warn(
-      'AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET environment variables not set. Using default credentials provider chain.',
+      'AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_SECRET (or AWS_SECRET_ACCESS_KEY) environment variables not set. Using default credentials provider chain.',
     );
   }
   const awsApiGenerateTempCredentialsForwarder = getAwsApiGenerateTempCredentialsForwarder({


### PR DESCRIPTION
This still allows both env variables but I wanted to add support for the more conventional name AWS_SECRET_ACCESS_KEY to avoid confusion like #65 

I'm also disabling node v12 in the github workflows because this project requires v14.17.0 or higher.